### PR TITLE
Explicitly sort annotated package and class names before adding them to MetadataSources to achieve platform independent repeatable builds

### DIFF
--- a/jpa2ddl-core/src/main/java/com/devskiller/jpa2ddl/SchemaGenerator.java
+++ b/jpa2ddl-core/src/main/java/com/devskiller/jpa2ddl/SchemaGenerator.java
@@ -62,9 +62,9 @@ class SchemaGenerator {
 						.applySettings(settings.getJpaProperties())
 						.build());
 
-		for (String packageName : settings.getPackages()) {
-			FileResolver.listClassNamesInPackage(packageName).forEach(metadata::addAnnotatedClassName);
-                	metadata.addPackage(packageName);
+		for (String packageName: settings.getPackages().stream().sorted().collect(Collectors.toList())) {
+			FileResolver.listClassNamesInPackage(packageName).stream().sorted().forEach(metadata::addAnnotatedClassName);
+			metadata.addPackage(packageName);
 		}
 
 		if (settings.getAction() != Action.UPDATE) {


### PR DESCRIPTION
Files.walkFileTree() has unpredictable iteration order, especially on different platforms like macOS and Windows. Also generated DDL script content depends on order in witch classes are added to metadata with MetadataSources.addAnnotatedClassName(). As a consequence, running same build on different platforms results in differing DDL scripts (in terms of table / column order). To ensure repeatable builds just explicitly sort package and class names before adding them to metadata.